### PR TITLE
refactor: remove unused pnpm scriptRemove the unused "zero-id" script package.json to tidy theproject's script and reduce confusion for contributors Thiske package metadata focused on active commands andidental invocation of no-op or deprecated script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "version": "changeset version",
     "release": "pnpm run build && changeset publish",
     "prepack": "turbo run prepack",
-    "zero-id": "zero-id",
     "build:force": "turbo build --force",
     "fix": "ultracite fix"
   },


### PR DESCRIPTION
- Removed the unused "zero" npm script from package- Deleted the "-id" in the package.json "scripts" section