### PR TITLE
feat(zero-id): addJS builds, and correct types fieldUpdate package.json to expose both ESM and CommonJS entrypointsand set main/module for compatibility different consumers. Fix thetypes path to point at the generated declaration file (index.d.cts).

### DIFF
--- a/.changeset/friendly-cherries-cross.md
+++ b/.changeset/friendly-cherries-cross.md
@@ -1,0 +1,5 @@
+---
+"@zeroopensource/zero-id": patch
+---
+
+feat(zero-id): addJS builds, and correct types fieldUpdate package.json to expose both ESM and CommonJS entrypointsand set main/module for compatibility different consumers. Fix thetypes path to point at the generated declaration file (index.d.cts).

--- a/packages/zero-id/package.json
+++ b/packages/zero-id/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/zeroopensource/zero-id/issues"
   },
   "type": "module",
-  "types": "./dist/zero-id.d.ts",
+  "types": "./dist/index.d.cts",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,16 @@
     "@zeroopensource/zero-cli": "latest"
   },
   "exports": {
-    ".": "./dist/index.mjs",
-    "./generate": "./dist/generate.mjs",
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./generate": {
+      "import": "./dist/generate.mjs",
+      "require": "./dist/generate.cjs"
+    },
     "./package.json": "./package.json"
-  }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs"
 }

--- a/packages/zero-id/tsdown.config.ts
+++ b/packages/zero-id/tsdown.config.ts
@@ -6,4 +6,12 @@ export default defineConfig({
     tsgo: true,
   },
   exports: true,
+  format: {
+    esm: {
+      target: ["es2015"],
+    },
+    cjs: {
+      target: ["node20"],
+    },
+  },
 });


### PR DESCRIPTION
Add exports for ./generate to provide dual ESM/C outputs.

Adjust tsdown config to both ESM and CJS bundles with targets:
ESM for modern runt (es2015) and CJS for20. enablespublishing compatible artifacts for consumers and tooling.